### PR TITLE
Improve CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 2.8.12)
 
-project (licensepp)
+project (licensepp CXX)
 
 option (test "Build all tests" OFF)
 option (BUILD_SHARED_LIBS "build shared libraries" ON)
@@ -35,10 +35,8 @@ if (APPLE)
     endif()
 endif()
 
-if(MSVC)
-    list (APPEND CMAKE_CXX_FLAGS " -std=c++11 -O3 ")
-else()
-    list (APPEND CMAKE_CXX_FLAGS " -std=c++11 -O3 -Wall -Werror ")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3 -Wall -Werror")
 endif()
 
 # Check for cryptopp (static)
@@ -64,15 +62,12 @@ set(LICENSEPP_SOURCE_FILES
     src/license.cc
 )
 
-if (BUILD_SHARED_LIBS)
-    add_library (licensepp-lib SHARED ${LICENSEPP_SOURCE_FILES})
-else()
-    add_library (licensepp-lib STATIC ${LICENSEPP_SOURCE_FILES})
-endif()
+add_library (licensepp-lib ${LICENSEPP_SOURCE_FILES})
 
 set_target_properties (licensepp-lib PROPERTIES
     VERSION ${LICENSEPP_SOVERSION}
 )
+target_include_directories (licensepp-lib PUBLIC $<INSTALL_INTERFACE:include>)
 target_link_libraries (licensepp-lib
     ${CRYPTOPP_LIBRARIES}
 )


### PR DESCRIPTION
- Add project language
- Remove unknown compiler flags for MSVC
  MSVC can not recognize `-std=c++11` or `-O3`.
  Except that,
  > list (APPEND CMAKE_CXX_FLAGS " -std=c++11 -O3 ")`

  will cause `CMAKE_CXX_FLAGS` set incorrectly:
  >  /DWIN32 /D_WINDOWS /W3 /GR /EHsc; -std=c++11 -O3

  the redundant semicolon here will be treated as a source file, which in turn will cause a build error.

![error](https://user-images.githubusercontent.com/5435649/82435362-c8208d00-9ac6-11ea-9e9d-2939077ca7de.png)

- Simplify usage of add_library
- Add missing INTERFACE_INCLUDE_DIRECTORIES to the cmake target