### PR TITLE
Fix compilation on macOS

### DIFF
--- a/src/json-object.h
+++ b/src/json-object.h
@@ -80,12 +80,6 @@ public:
         return get<bool>(key, defaultValue);
     }
 
-    inline const char* getCString(const std::string& key,
-                                  const char* defaultValue = "") const
-    {
-        return getString(key, defaultValue).c_str();
-    }
-
     inline bool hasKey(const std::string& key) const
     {
          return m_root.count(key) > 0;


### PR DESCRIPTION
Remove unused function to fix a compilation error on macOS:

```
FAILED: CMakeFiles/licensepp-lib.dir/src/json-object.cc.o 
/Library/Developer/CommandLineTools/usr/bin/c++ -DLICENSEPP_SOVERSION=\"1.0.6\" -DRIPE_VERSION=\"4.0.1-custom-static\" -I/Users/vagrant/Data/installed/x64-osx/include -I/Users/vagrant/Data/buildtrees/licensepp/x64-osx-dbg -I/Users/vagrant/Data/buildtrees/licensepp/src/612a3d3e3c-fee8106458.clean -fPIC -std=c++11 -O3 -Wall -Werror -g -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk -MD -MT CMakeFiles/licensepp-lib.dir/src/json-object.cc.o -MF CMakeFiles/licensepp-lib.dir/src/json-object.cc.o.d -o CMakeFiles/licensepp-lib.dir/src/json-object.cc.o -c /Users/vagrant/Data/buildtrees/licensepp/src/612a3d3e3c-fee8106458.clean/src/json-object.cc
In file included from /Users/vagrant/Data/buildtrees/licensepp/src/612a3d3e3c-fee8106458.clean/src/json-object.cc:11:
/Users/vagrant/Data/buildtrees/licensepp/src/612a3d3e3c-fee8106458.clean/src/json-object.h:86:16: error: returning address of local temporary object [-Werror,-Wreturn-stack-address]
        return getString(key, defaultValue).c_str();
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Please see https://github.com/microsoft/vcpkg/pull/30663#issuecomment-1498533463